### PR TITLE
Updated code to use S3 bucket name and AWS region from GitHub secrets

### DIFF
--- a/.github/workflows/apply-nic-napv5.yml
+++ b/.github/workflows/apply-nic-napv5.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches: apply-nic-napv5
 env:
-  AWS_REGION: us-east-1
+#  AWS_REGION: us-east-1
+  TF_VAR_AWS_S3_BUCKET_NAME: ${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}
+  TF_VAR_AWS_REGION: ${{ secrets.TF_VAR_AWS_REGION }}
 jobs:
   terraform_bootstrap:
     name: "Bootstrap S3/DynamoDB"
@@ -21,7 +23,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -66,7 +68,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -74,7 +76,9 @@ jobs:
 
       - name: Initialize Terraform (S3 Backend)
         run: |
-          terraform init
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Plan
         if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -94,7 +98,6 @@ jobs:
       - name: Terraform Apply
         if: github.event_name == 'push' && github.ref == 'refs/heads/apply-nic-napv5' && steps.check_changes.outputs.has_changes == 'true'
         run: terraform apply -auto-approve tfplan
-
       
   terraform_eks:
     name: "AWS EKS"
@@ -113,14 +116,17 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
    
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Plan
         if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -158,13 +164,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Plan
         if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -208,14 +217,17 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-        aws-region: ${{ env.AWS_REGION }}
+        aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
 
 
     - name: Terraform Init (EKS)
-      run: terraform init
+      run: |
+        terraform init \
+          -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+          -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
       working-directory: ./eks-cluster
 
     - name: Print EKS Terraform Outputs
@@ -306,7 +318,10 @@ jobs:
         kubectl cp ${{ github.workspace }}/policy/compiled_policy.tgz $NGINX_POD:/etc/app_protect/bundles/compiled_policy.tgz -n nginx-ingress 
 
     - name: Terraform Init
-      run: terraform init
+      run: |
+        terraform init \
+          -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+          -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
     - name: Terraform Plan
       run: |
@@ -343,13 +358,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Validate
         run: terraform validate -no-color

--- a/.github/workflows/destroy-nic-napv5.yml
+++ b/.github/workflows/destroy-nic-napv5.yml
@@ -5,7 +5,9 @@ on:
       - destroy-nic-napv5
   pull_request:
 env:
-  AWS_REGION: us-east-1
+#  AWS_REGION: us-east-1
+  TF_VAR_AWS_S3_BUCKET_NAME: ${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}
+  TF_VAR_AWS_REGION: ${{ secrets.TF_VAR_AWS_REGION }}
 jobs:
   terraform_arcadia:
     name: "Destroy Arcadia WebApp"
@@ -24,13 +26,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
       
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Validate
         run: terraform validate -no-color
@@ -71,13 +76,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Destroy
         run: terraform destroy -auto-approve -lock=false
@@ -99,13 +107,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Plan (Destroy)
         run: |
@@ -152,13 +163,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Plan (Destroy)
         if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -196,13 +210,16 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
+            -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"
 
       - name: Terraform Plan (Destroy)
         if: github.event_name == 'pull_request' || github.event_name == 'push'
@@ -244,12 +261,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.TF_VAR_AWS_REGION }}
 
       - name: Set Bucket Name
         id: set_bucket
         run: |
-          echo "bucket_name= your-unique-bucket-name" >> $GITHUB_OUTPUT
+          echo "bucket_name= ${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" >> $GITHUB_OUTPUT
 
       - name: Nuclear S3 Bucket Deletion
         run: |

--- a/arcadia/backend.tf
+++ b/arcadia/backend.tf
@@ -1,8 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "your-unique-bucket-name"         # Replace with your actual bucket name  
     key            = "arcadia/terraform.tfstate"       # Path to state file
-    region         = "us-east-1"                     # AWS region
     dynamodb_table = "terraform-lock-table"          # DynamoDB table for state locking
     encrypt        = true                            # Encrypt state file at rest
   }

--- a/arcadia/data.tf
+++ b/arcadia/data.tf
@@ -2,9 +2,9 @@
 data "terraform_remote_state" "infra" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME       # Your S3 bucket name
     key    = "infra/terraform.tfstate"       # Path to infra's state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                    # AWS region
   }
 }
 
@@ -12,18 +12,18 @@ data "terraform_remote_state" "infra" {
 data "terraform_remote_state" "nap" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME       # Your S3 bucket name
     key    = "nap/terraform.tfstate"         # Path to NAP state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                    # AWS region
   }
 }
 
 data "terraform_remote_state" "eks" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME       # Your S3 bucket name
     key    = "eks-cluster/terraform.tfstate"  # Path to EKS state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                     # AWS region
   }
 }
 

--- a/arcadia/variables.tf
+++ b/arcadia/variables.tf
@@ -1,0 +1,11 @@
+variable "AWS_REGION" {
+  description = "aws region"
+  type        = string
+  default     = ""
+}
+
+variable "AWS_S3_BUCKET_NAME" {
+  description = "aws s3 bucket name"
+  type        = string
+  default     = ""
+}

--- a/eks-cluster/backend.tf
+++ b/eks-cluster/backend.tf
@@ -1,8 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "your-unique-bucket-name"       # Your S3 bucket name
     key            = "eks-cluster/terraform.tfstate"       # Path to state file
-    region         = "us-east-1"                     # AWS region
     dynamodb_table = "terraform-lock-table"          # DynamoDB table for state locking
     encrypt        = true                        
   }

--- a/eks-cluster/data.tf
+++ b/eks-cluster/data.tf
@@ -1,9 +1,9 @@
 data "terraform_remote_state" "infra" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME       # Your S3 bucket name
     key    = "infra/terraform.tfstate"       # Path to infra's state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                    # AWS region
   }
 }
 

--- a/eks-cluster/variables.tf
+++ b/eks-cluster/variables.tf
@@ -5,10 +5,22 @@ variable "admin_src_addr" {
   default     = "0.0.0.0/0"
 }
 
+variable "AWS_REGION" {
+  description = "aws region"
+  type        = string
+  default     = ""
+}
+
+variable "AWS_S3_BUCKET_NAME" {
+  description = "aws s3 bucket name"
+  type        = string
+  default     = ""
+}
+
 variable "aws_region" {
   description = "The AWS region to deploy the EKS cluster"
   type        = string
-  default     = "us-east-1"
+  default     = "ap-south-1"
 }
 
 #AWS

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,8 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "your-unique-bucket-name"       # Your S3 bucket name
     key            = "infra/terraform.tfstate"       # Path to state file
-    region         = "us-east-1"                     # AWS region
     dynamodb_table = "terraform-lock-table"          # DynamoDB table for state locking
     encrypt        = true                        
   }

--- a/infra/network.tf
+++ b/infra/network.tf
@@ -10,7 +10,7 @@ module "vpc" {
 
   name = "${var.project_prefix}-vpc-${random_id.build_suffix.hex}"
   cidr = var.cidr
-  azs  = var.azs
+  azs  = local.azs
 
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -31,9 +31,9 @@ resource "aws_internet_gateway" "igw" {
 
 # Subnets
 resource "aws_subnet" "management" {
-  for_each          = toset(var.azs)
+  for_each          = toset(local.azs)
   vpc_id            = module.vpc.vpc_id
-  cidr_block        = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(var.azs, each.key) * 4)
+  cidr_block        = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(local.azs, each.key) * 4)
   availability_zone = each.key
   tags = {
     Name = format("%s-mgmt-subnet-%s", var.project_prefix, each.key)
@@ -41,9 +41,9 @@ resource "aws_subnet" "management" {
 }
 
 resource "aws_subnet" "internal" {
-  for_each          = toset(var.azs)
+  for_each          = toset(local.azs)
   vpc_id            = module.vpc.vpc_id
-  cidr_block        = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(var.azs, each.key) * 4 + 1)
+  cidr_block        = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(local.azs, each.key) * 4 + 1)
   availability_zone = each.key
   tags = {
     Name = format("%s-int-subnet-%s", var.project_prefix, each.key)
@@ -51,9 +51,9 @@ resource "aws_subnet" "internal" {
 }
 
 resource "aws_subnet" "external" {
-  for_each                = toset(var.azs)
+  for_each                = toset(local.azs)
   vpc_id                  = module.vpc.vpc_id
-  cidr_block              = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(var.azs, each.key) * 4 + 2)
+  cidr_block              = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(local.azs, each.key) * 4 + 2)
   map_public_ip_on_launch = true
   availability_zone       = each.key
   tags = {
@@ -62,9 +62,9 @@ resource "aws_subnet" "external" {
 }
 
 resource "aws_subnet" "app_cidr" {
-  for_each          = toset(var.azs)
+  for_each          = toset(local.azs)
   vpc_id            = module.vpc.vpc_id
-  cidr_block        = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(var.azs, each.key) * 4 + 3)
+  cidr_block        = cidrsubnet(module.vpc.vpc_cidr_block, 4, index(local.azs, each.key) * 4 + 3)
   availability_zone = each.key
   tags = {
     Name = format("%s-app-subnet-%s", var.project_prefix, each.key)
@@ -85,25 +85,25 @@ resource "aws_route_table" "main" {
 
 # Route Table Associations
 resource "aws_route_table_association" "subnet-association-internal" {
-  for_each       = toset(var.azs)
+  for_each       = toset(local.azs)
   subnet_id      = aws_subnet.internal[each.key].id
   route_table_id = aws_route_table.main.id
 }
 
 resource "aws_route_table_association" "subnet-association-management" {
-  for_each       = toset(var.azs)
+  for_each       = toset(local.azs)
   subnet_id      = aws_subnet.management[each.key].id
   route_table_id = aws_route_table.main.id
 }
 
 resource "aws_route_table_association" "subnet-association-external" {
-  for_each       = toset(var.azs)
+  for_each       = toset(local.azs)
   subnet_id      = aws_subnet.external[each.key].id
   route_table_id = aws_route_table.main.id
 }
 
 resource "aws_route_table_association" "subnet-association-app-cidr" {
-  for_each       = toset(var.azs)
+  for_each       = toset(local.azs)
   subnet_id      = aws_subnet.app_cidr[each.key].id
   route_table_id = aws_route_table.main.id
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -12,7 +12,7 @@ output "build_suffix" {
 }
 
 # AWS Region and Availability Zones
-output "AWS_REGION" {
+output "aws_region" {
   value = var.AWS_REGION
 }
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -62,44 +62,44 @@ output "management_cidr_blocks" {
 
 # Specific AZ Subnet CIDR Blocks
 output "public_az1_cidr_block" {
-  value = aws_subnet.external[element(tolist(var.azs), 0)].cidr_block  # Reference AZ1's public CIDR
+  value = aws_subnet.external[element(tolist(local.azs), 0)].cidr_block  # Reference AZ1's public CIDR
 }
 
 output "private_az1_cidr_block" {
-  value = aws_subnet.internal[element(tolist(var.azs), 0)].cidr_block  # Reference AZ1's private CIDR
+  value = aws_subnet.internal[element(tolist(local.azs), 0)].cidr_block  # Reference AZ1's private CIDR
 }
 
 output "public_az2_cidr_block" {
-  value = aws_subnet.external[element(tolist(var.azs), 1)].cidr_block  # Reference AZ2's public CIDR
+  value = aws_subnet.external[element(tolist(local.azs), 1)].cidr_block  # Reference AZ2's public CIDR
 }
 
 output "private_az2_cidr_block" {
-  value = aws_subnet.internal[element(tolist(var.azs), 1)].cidr_block  # Reference AZ2's private CIDR
+  value = aws_subnet.internal[element(tolist(local.azs), 1)].cidr_block  # Reference AZ2's private CIDR
 }
 
 # Subnet IDs for specific AZs
 output "ext_subnet_az1" {
-  value = aws_subnet.external[element(tolist(var.azs), 0)].id  # Reference AZ1's external subnet ID
+  value = aws_subnet.external[element(tolist(local.azs), 0)].id  # Reference AZ1's external subnet ID
 }
 
 output "ext_subnet_az2" {
-  value = aws_subnet.external[element(tolist(var.azs), 1)].id  # Reference AZ2's external subnet ID
+  value = aws_subnet.external[element(tolist(local.azs), 1)].id  # Reference AZ2's external subnet ID
 }
 
 output "int_subnet_az1" {
-  value = aws_subnet.internal[element(tolist(var.azs), 0)].id  # Reference AZ1's internal subnet ID
+  value = aws_subnet.internal[element(tolist(local.azs), 0)].id  # Reference AZ1's internal subnet ID
 }
 
 output "int_subnet_az2" {
-  value = aws_subnet.internal[element(tolist(var.azs), 1)].id  # Reference AZ2's internal subnet ID
+  value = aws_subnet.internal[element(tolist(local.azs), 1)].id  # Reference AZ2's internal subnet ID
 }
 
 output "mgmt_subnet_az1" {
-  value = aws_subnet.management[element(tolist(var.azs), 0)].id  # Reference AZ1's management subnet ID
+  value = aws_subnet.management[element(tolist(local.azs), 0)].id  # Reference AZ1's management subnet ID
 }
 
 output "mgmt_subnet_az2" {
-  value = aws_subnet.management[element(tolist(var.azs), 1)].id  # Reference AZ2's management subnet ID
+  value = aws_subnet.management[element(tolist(local.azs), 1)].id  # Reference AZ2's management subnet ID
 }
 
 # CIDR Block for Application and EKS Subnets

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -12,12 +12,12 @@ output "build_suffix" {
 }
 
 # AWS Region and Availability Zones
-output "aws_region" {
-  value = var.aws_region
+output "AWS_REGION" {
+  value = var.AWS_REGION
 }
 
 output "azs" {
-  value = var.azs
+  value = local.azs
 }
 
 # VPC Details

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,5 +1,5 @@
 # AWS Provider Configuration
 provider "aws" {
-  region = var.aws_region
+  region = var.AWS_REGION
 }
 

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,6 +1,6 @@
 project_prefix = "gh-hk-nic-nap"   #"Your project identifier name in lowercase letters only - this will be applied as a prefix to all assets"
 resource_owner = "karthik"
 # aws_region = "ap-south-1"
-azs = ["${AWS_REGION}a", "${AWS_REGION}b"]
+# azs = ["${var.AWS_REGION}a", "${var.AWS_REGION}b"]
 
 

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,6 +1,6 @@
 project_prefix = "gh-hk-nic-nap"   #"Your project identifier name in lowercase letters only - this will be applied as a prefix to all assets"
 resource_owner = "karthik"
-aws_region = "ap-south-1"
-azs = ["ap-south-1a", "ap-south-1b"]
+# aws_region = "ap-south-1"
+azs = ["${AWS_REGION}a", "${AWS_REGION}b"]
 
 

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,6 @@
+project_prefix = "gh-hk-nic-nap"   #"Your project identifier name in lowercase letters only - this will be applied as a prefix to all assets"
+resource_owner = "karthik"
+aws_region = "ap-south-1"
+azs = ["ap-south-1a", "ap-south-1b"]
+
+

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -2,5 +2,3 @@ project_prefix = "gh-hk-nic-nap"   #"Your project identifier name in lowercase l
 resource_owner = "karthik"
 # aws_region = "ap-south-1"
 # azs = ["${var.AWS_REGION}a", "${var.AWS_REGION}b"]
-
-

--- a/infra/terraform.tfvars.examples
+++ b/infra/terraform.tfvars.examples
@@ -1,6 +1,2 @@
 project_prefix = "<any name> "   #"Your project identifier name in lowercase letters only - this will be applied as a prefix to all assets"
 resource_owner = "Your-name"
-aws_region = "us-east-1"
-azs = ["us-east-1a", "us-east-1b"]
-
-

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -5,11 +5,24 @@ variable "project_prefix" {
   description = "This value is inserted at the beginning of each AWS object (alpha-numeric, no special character)"
 }
 
+variable "AWS_REGION" {
+  description = "aws region"
+  type        = string
+  default     = ""
+}
+
+variable "AWS_S3_BUCKET_NAME" {
+  description = "aws s3 bucket name"
+  type        = string
+  default     = ""
+}
+
 variable "aws_region" {
   description = "aws region"
   type        = string
-  default     = "us-east-1"
+  default     = "ap-south-1"
 }
+
 variable "resource_owner" {
   type        = string
   description = "owner of the deployment, for tagging purposes"
@@ -24,8 +37,8 @@ variable "cidr" {
     condition     = can(regex("^([0-9]{1,3}.){3}[0-9]{1,3}($|/(15|16|24))$", var.cidr))
     error_message = "The value must conform to a CIDR block format."
   }
-
 }
+
 variable "azs" {
   description = "Availability Zones"
   type        = list

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -39,10 +39,10 @@ variable "cidr" {
   }
 }
 
-variable "azs" {
-  description = "Availability Zones"
-  type        = list
-}
+# variable "azs" {
+#   description = "Availability Zones"
+#   type        = list
+# }
 
 locals {
   azs = ["${var.AWS_REGION}a", "${var.AWS_REGION}b"]

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -17,11 +17,11 @@ variable "AWS_S3_BUCKET_NAME" {
   default     = ""
 }
 
-variable "aws_region" {
-  description = "aws region"
-  type        = string
-  default     = "ap-south-1"
-}
+# variable "aws_region" {
+#   description = "aws region"
+#   type        = string
+#   default     = "ap-south-1"
+# }
 
 variable "resource_owner" {
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -43,6 +43,11 @@ variable "azs" {
   description = "Availability Zones"
   type        = list
 }
+
+locals {
+  azs = ["${var.AWS_REGION}a", "${var.AWS_REGION}b"]
+}
+
 variable "create_nat_gateway" {
   type        = bool
   default     = false

--- a/nap/backend.tf
+++ b/nap/backend.tf
@@ -1,8 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "your-unique-bucket-name" # Replace with your actual bucket name
     key            = "nap/terraform.tfstate"       # Path to state file
-    region         = "us-east-1"                     # AWS region
     dynamodb_table = "terraform-lock-table"          # DynamoDB table for state locking
     encrypt        = true                            # Encrypt state file at rest
   }

--- a/nap/data.tf
+++ b/nap/data.tf
@@ -1,9 +1,9 @@
 data "terraform_remote_state" "infra" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket = var.AWS_S3_BUCKET_NAME       # Your S3 bucket name
     key    = "infra/terraform.tfstate"       # Path to infra's state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                    # AWS region
   }
 }
 
@@ -11,9 +11,9 @@ data "terraform_remote_state" "infra" {
 data "terraform_remote_state" "eks" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME        # Your S3 bucket name
     key    = "eks-cluster/terraform.tfstate" # Path to EKS state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                    # AWS region
   }
 }
 

--- a/nap/variables.tf
+++ b/nap/variables.tf
@@ -22,3 +22,14 @@ variable "nginx_jwt" {
   sensitive   = true  # Mark as sensitive to avoid exposing it in logs
 }
 
+variable "AWS_REGION" {
+  description = "aws region"
+  type        = string
+  default     = ""
+}
+
+variable "AWS_S3_BUCKET_NAME" {
+  description = "aws s3 bucket name"
+  type        = string
+  default     = ""
+}

--- a/policy/backend.tf
+++ b/policy/backend.tf
@@ -1,8 +1,6 @@
 terraform {
   backend "s3" {
-    bucket         = "your-unique-bucket-name"         # Replace with your actual bucket name
     key            = "policy/terraform.tfstate"       # Path to state file
-    region         = "us-east-1"                     # AWS region
     dynamodb_table = "terraform-lock-table"          # DynamoDB table for state locking
     encrypt        = true                            # Encrypt state file at rest
   }

--- a/policy/data.tf
+++ b/policy/data.tf
@@ -2,9 +2,9 @@
 data "terraform_remote_state" "infra" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket namee
+    bucket =  var.AWS_S3_BUCKET_NAME        # Your S3 bucket namee
     key    = "infra/terraform.tfstate"       # Path to infra's state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                      # AWS region
   }
 }
 
@@ -12,9 +12,9 @@ data "terraform_remote_state" "infra" {
 data "terraform_remote_state" "eks" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME        # Your S3 bucket name
     key    = "eks-cluster/terraform.tfstate" # Path to EKS state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                       # AWS region
   }
 }
 
@@ -22,9 +22,9 @@ data "terraform_remote_state" "eks" {
 data "terraform_remote_state" "nap" {
   backend = "s3"
   config = {
-    bucket =  "your-unique-bucket-name"       # Your S3 bucket name
+    bucket =  var.AWS_S3_BUCKET_NAME        # Your S3 bucket name
     key    = "nap/terraform.tfstate"         # Path to NAP state file
-    region = "us-east-1"                     # AWS region
+    region = var.AWS_REGION                       # AWS region
   }
 }
 

--- a/policy/variables.tf
+++ b/policy/variables.tf
@@ -1,0 +1,11 @@
+variable "AWS_REGION" {
+  description = "aws region"
+  type        = string
+  default     = ""
+}
+
+variable "AWS_S3_BUCKET_NAME" {
+  description = "aws s3 bucket name"
+  type        = string
+  default     = ""
+}

--- a/s3/bootstrap.tf
+++ b/s3/bootstrap.tf
@@ -49,14 +49,14 @@ locals {
   )
   
   # Generate unique bucket name if needed
-  unique_bucket_name = "${var.AWS_S3_BUCKET_NAME}-${data.aws_caller_identity.current.account_id}"
+  # unique_bucket_name = "${var.AWS_S3_BUCKET_NAME}-${data.aws_caller_identity.current.account_id}"
 }
 
 # S3 Bucket Resources
 resource "aws_s3_bucket" "terraform_state" {
   count = local.bucket_exists ? 0 : 1
 
-  bucket        = local.unique_bucket_name
+  bucket        = var.AWS_S3_BUCKET_NAME
   force_destroy = false
 
   tags = {

--- a/s3/bootstrap.tf
+++ b/s3/bootstrap.tf
@@ -3,7 +3,7 @@
 data "external" "bucket_check" {
   program = ["bash", "-c", <<EOT
     # Ensure consistent JSON output
-    output=$(aws s3api head-bucket --bucket ${var.tf_state_bucket} --region ${var.aws_region} 2>&1)
+    output=$(aws s3api head-bucket --bucket ${var.AWS_S3_BUCKET_NAME} --region ${var.AWS_REGION} 2>&1)
     status=$?
     
     if [ $status -eq 0 ]; then
@@ -23,7 +23,7 @@ data "external" "dynamodb_table_check" {
   program = ["bash", "-c", <<EOT
     if output=$(aws dynamodb describe-table \
       --table-name terraform-lock-table \
-      --region ${var.aws_region} 2>&1); then
+      --region ${var.AWS_REGION} 2>&1); then
       echo '{"exists":"true"}'
     elif echo "$output" | grep -q 'ResourceNotFoundException'; then
       echo '{"exists":"false"}'
@@ -49,7 +49,7 @@ locals {
   )
   
   # Generate unique bucket name if needed
-  unique_bucket_name = "${var.tf_state_bucket}-${data.aws_caller_identity.current.account_id}"
+  unique_bucket_name = "${var.AWS_S3_BUCKET_NAME}-${data.aws_caller_identity.current.account_id}"
 }
 
 # S3 Bucket Resources

--- a/s3/iam.tf
+++ b/s3/iam.tf
@@ -38,8 +38,8 @@ resource "aws_iam_policy" "terraform_state_access" {
         "s3:ListBucket"
       ],
       Resource = [
-        "arn:aws:s3:::${var.tf_state_bucket}",
-        "arn:aws:s3:::${var.tf_state_bucket}/*"
+        "arn:aws:s3:::${var.AWS_S3_BUCKET_NAME}",
+        "arn:aws:s3:::${var.AWS_S3_BUCKET_NAME}/*"
       ]
     }]
   })

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -6,7 +6,7 @@ output "s3_bucket_created" {
 }
 
 output "s3_bucket_name" {
-  value       = local.bucket_exists ? var.tf_state_bucket : aws_s3_bucket.terraform_state[0].bucket
+  value       = local.bucket_exists ? var.AWS_S3_BUCKET_NAME : aws_s3_bucket.terraform_state[0].bucket
   description = "Name of the S3 bucket used for Terraform state"
 }
 

--- a/s3/provider.tf
+++ b/s3/provider.tf
@@ -1,5 +1,5 @@
 # AWS Provider Configuration
 provider "aws" {
-  region = var.aws_region
+  region = var.AWS_REGION
 }
 

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -1,16 +1,20 @@
-variable "tf_state_bucket" {
-  type        = string
-  description = "S3 bucket for Terraform state"
-  default     = "your-unique-bucket-name" 
-}
+# variable "tf_state_bucket" {
+#   type        = string
+#   description = "S3 bucket for Terraform state"
+#   default     = "your-unique-bucket-name"
+# }
 variable "create_iam_resources" {
   description = "Whether to create IAM resources (role and policy)."
   type        = bool
   default     = true
 }
 
-variable "aws_region" {
+variable "AWS_REGION" {
   description = "aws region"
   type        = string
-  default     = "us-east-1"
+}
+
+variable "AWS_S3_BUCKET_NAME" {
+  description = "aws s3 bucket name"
+  type        = string
 }


### PR DESCRIPTION
New changes:
1. Added GitHub secrets for AWS_S3_BUCKET_NAME and AWS_REGION and declared them as environment variables in workflow file
  TF_VAR_AWS_S3_BUCKET_NAME: ${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}
  TF_VAR_AWS_REGION: ${{ secrets.TF_VAR_AWS_REGION }}

2. Initialized backend code for those variables in workflow file under jobs wherever required, instead of declaring them in backend.tf to remove redunduncy

  - name: Terraform Init
    run: |
      terraform init \
        -backend-config="bucket=${{ secrets.TF_VAR_AWS_S3_BUCKET_NAME }}" \
        -backend-config="region=${{ secrets.TF_VAR_AWS_REGION }}"

3. Defined AWS_REGION and AWS_S3_BUCKET_NAME in variables.tf under folders wherever required

4. Updated "bucket" and "region" variables in data.tf to use values declared in GitHub secrets

  config = {
    bucket = var.AWS_S3_BUCKET_NAME       # Your S3 bucket name
    region = var.AWS_REGION                    # AWS region
  }

5. Replaced "tf_state_bucket" variable with "AWS_S3_BUCKET_NAME" and "aws_region" with "AWS_REGION" in S3 folder

6. Updated variable "azs" with "local.azs" and made it dynamic to build the AZ list based on region in "infra" folder
Note :- We might need to add a note in our readme highlighting users need to use region where atleast two availability zones are supported

7. Replaced "var.azs" with "local.azs" in outputs.tf and network.tf under "infra" folder

8. "aws_region" and "azs" are no longer needed to be declared in infra->terraform.tfvars

9. Commented out "unique_bucket_name" variable, since we cannot use this in other references once we start using S3 bucket name from GitHub secrets

Please refer below pipelines for more information.
Deploy -> https://github.com/hadagalikarthik/nginx_automation_examples/actions/runs/14154048262
Destroy -> https://github.com/hadagalikarthik/nginx_automation_examples/actions/runs/14154356076

Below attached screenshot of my GitHub secrets.
<img width="790" alt="Screenshot 2025-03-30 at 14 44 38" src="https://github.com/user-attachments/assets/4eaa29da-ea04-4bed-af40-322c10b0a21e" />
